### PR TITLE
Added simplistic autocomplete functionality for InputList.

### DIFF
--- a/example/src/NestedFormExample.js
+++ b/example/src/NestedFormExample.js
@@ -22,7 +22,7 @@ class NestedFormExample extends Component {
   }
 
   handleSubmit(formData, cb) {
-    this.setState({ formData, })
+    this.setState({ formData, });
     cb();
   }
 
@@ -31,7 +31,7 @@ class NestedFormExample extends Component {
       <div>
         <h2>Nested form</h2>
         <SourceCode name="nestedFormExample" />
-        
+
         <Form
           initialState={this.state.initialState}
           submitButtonText="Save"
@@ -40,35 +40,38 @@ class NestedFormExample extends Component {
           submittingText="Saving..."
           onSubmit={this.handleSubmit}
         >
-          <Field name="firstname" label="First name" />
-          <Field name="lastname" label="Last name" />
+          <Field name="firstname" label="First name" autoComplete="nope" />
+          <Field name="lastname" label="Last name" autoComplete="nope" />
           <h3>Nicknames</h3>
+
+          <SubForm name="nickname">
+            <Field name="nickname" label="Nickname" autoComplete="nope" />
+          </SubForm>
+
+          <h3>Address</h3>
           <InputList
-            name="nicknames"
+            name="addresses"
             of={
               <InputListItem>
-                <Field name="nickname" label="Nickname" />
+                <Field name="street" label="Street" autoComplete="street-address" />
+                <Field name="city" label="City" autoComplete="address-level2" />
+                <Field name="zip" label="Zip code" autoComplete="postal-code" />
               </InputListItem>
             }
           />
-          <h3>Address</h3>
-          <SubForm name="address">
-            <Field name="street" label="Street" />
-            <Field name="city" label="City" />
-            <Field name="zip" label="Zip code" />
-          </SubForm>
+
           <h3>Hobbies</h3>
           <InputList
             name="hobbies"
             of={
               <InputListItem>
-                <Field name="name" label="Hobby name" />
-                <Field name="description" label="Hobby description" />
+                <Field name="name" label="Hobby name" autoComplete="nope" />
+                <Field name="description" label="Hobby description" autoComplete="nope" />
               </InputListItem>
             }
           />
         </Form>
-        <FormData formData={this.state.formData} />        
+        <FormData formData={this.state.formData} />
       </div>
     );
   }

--- a/src/Field.js
+++ b/src/Field.js
@@ -316,6 +316,7 @@ Field.propTypes = {
   options: PropTypes.array,
   children: PropTypes.node,
   controlGroupClass: PropTypes.string,
+  autoComplete: PropTypes.string,
 };
 
 Field.defaultProps = {

--- a/src/Input.js
+++ b/src/Input.js
@@ -19,7 +19,7 @@ const Input = (props) => {
   return (
     <input
       type={type}
-      autoComplete="off"
+      autoComplete={props.autoComplete || 'off'}
       maxLength={maxLength}
       name={name}
       value={props.value || ''}
@@ -52,6 +52,7 @@ Input.propTypes = {
   placeholder: PropTypes.string,
   min: PropTypes.string,
   max: PropTypes.string,
+  autoComplete: PropTypes.string,
 };
 
 Input.defaultProps = {

--- a/src/InputList.js
+++ b/src/InputList.js
@@ -143,13 +143,24 @@ class InputList extends Component {
       removeButtonClassName,
     } = this.props;
 
+    const storeName = `${this.context.store}-${this.props.name}-${this.state.idMap[index]}`;
+
+    // Enrich all children with the same autoComplete section id.
+    const children = React.Children.map(
+      this.props.of.props.children,
+      (child) => {
+        return React.cloneElement(child, {
+          autoComplete: `section-${storeName} ${child.props.autoComplete}`,
+        });
+      });
+
     const item = React.cloneElement(this.props.of, {
-      store: `${this.context.store}-${this.props.name}-${this.state.idMap[index]}`,
+      store: `${storeName}`,
       addListItem: this.addListItem,
       removeListItem: this.removeListItem,
-    });
+    }, children);
 
-    const component = (
+    return (
       <div key={this.state.idMap[index]} className="form__input-list-item">
         { item }
         {
@@ -163,13 +174,12 @@ class InputList extends Component {
         }
       </div>
     );
-    return component;
   }
 
   createItems() {
     const items = [];
 
-    for (let i = 0; i < this.state.length; i++) { // eslint-disable-line no-plusplus  
+    for (let i = 0; i < this.state.length; i++) { // eslint-disable-line no-plusplus
       const item = this.createItem(i);
       items.push(item);
     }


### PR DESCRIPTION
**Background**: Want to support autocomplete for the `InputListItem` in an `InputList`. 

**Issue**: The browser is not able to distinguish between e.g. two adresses; if autocompleting the last address it fills in the first address.

**Solution proposal**: When cloning the `of` prop of the InputList, enrich all the children with a unique [autofill-scope](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill-scope) to help the browser group together fields for autofilling. In particular, we can use `[section-](optional)` as the autofill-scope.

Note that passing children to
```
React.cloneElement(
  element,
  [props],
  [...children]
)
```
will replace existing children.

**Comments**: This is by no means a rigorous solution, it's just a quick fix. I've updated `NestedFormExample` to demo the changes.
